### PR TITLE
Add missing cstdio include

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,7 +1,5 @@
 #include <pprintpp/pprintpp.hpp>
 
-#include <cstdio>
-
 int main()
 {
     pprintf("{} hello {s}! {}\n", 1, "world", 2.0) ;

--- a/include/pprintpp/pprintpp.hpp
+++ b/include/pprintpp/pprintpp.hpp
@@ -26,6 +26,8 @@
 #include "stl_symbols.hpp"
 #include "charlist.hpp"
 
+#include <cstdio>
+
 namespace pprintpp {
 
 template <typename T> struct always_false { static constexpr bool value {false}; };


### PR DESCRIPTION
pprintpp.hpp uses printf(), but never adds the required include for
that.

Fixes #16