### PR TITLE
Fix warnings when compiling with gcc -Wpedantic

### DIFF
--- a/include/pprintpp/pprintpp.hpp
+++ b/include/pprintpp/pprintpp.hpp
@@ -169,12 +169,12 @@ template <typename ... Ts>
 make_t<Ts...> tie_types(Ts...);
 
 #define AUTOFORMAT(s, ...) \
-    ({ \
+    []{ \
         struct strprov { static constexpr const char * str() { return static_cast<const char*>(s); } }; \
         using paramtypes = decltype(pprintpp::tie_types(__VA_ARGS__)); \
         using af = pprintpp::autoformat_t<strprov, paramtypes>; \
-        af::str(); \
-    })
+        return af::str(); \
+    }()
 
 #define pprintf(s, ...) printf(AUTOFORMAT(s, ## __VA_ARGS__), ## __VA_ARGS__);
 


### PR DESCRIPTION
Compiling with -Wpedantic produces this:

```
/tmp/pprintpp/example > g++ -Wpedantic -I../include main.cpp
In file included from main.cpp:1:
main.cpp: In function ‘int main()’:
../include/pprintpp/pprintpp.hpp:172:5: warning: ISO C++ forbids braced-groups within expressions [-Wpedantic]
  172 |     ({ \
      |     ^
../include/pprintpp/pprintpp.hpp:179:32: note: in expansion of macro ‘AUTOFORMAT’
  179 | #define pprintf(s, ...) printf(AUTOFORMAT(s, ## __VA_ARGS__), ## __VA_ARGS__);
      |                                ^~~~~~~~~~
main.cpp:5:5: note: in expansion of macro ‘pprintf’
    5 |     pprintf("{} hello {s}! {}\n", 1, "world", 2.0) ;
      |     ^~~~~~~

```

Maybe the AUTOFORMAT macro should use a lambda expression? Or at least this fix should be mentioned in the FAQ?

**P.S.**: There is an error in the README.md:
Should be:
```
#define pprintf(fmtstr, ...) printf(AUTOFORMAT(fmtstr, ## __VA_ARGS__), ## __VA_ARGS__)
                                                           ^^^^^^^^^
```
Instead of
```
#define pprintf(fmtstr, ...) printf(AUTOFORMAT(fmtstr, ## __VA_ARGS), ## __VA_ARGS__)
```

-- Benjamin