### PR TITLE
CMakeLists.txt adopted to be included by FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,14 @@ target_include_directories(${PROJECT_NAME} INTERFACE
   )
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
 
-enable_testing()
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  enable_testing()
 
-add_executable(${PROJECT_NAME}-test test/main.cpp)
-add_test(NAME ${PROJECT_NAME}-test COMMAND ${PROJECT_NAME}-test)
-target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-target_compile_options(${PROJECT_NAME}-test PRIVATE -Wall -Wextra -Werror)
+  add_executable(${PROJECT_NAME}-test test/main.cpp)
+  add_test(NAME ${PROJECT_NAME}-test COMMAND ${PROJECT_NAME}-test)
+  target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+  target_compile_options(${PROJECT_NAME}-test PRIVATE -Wall -Wextra -Werror)
+endif()
 
 set(CPACK_PACKAGE_NAME "pprintpp")
 set(CPACK_PACKAGE_VENDOR "galowicz.de")


### PR DESCRIPTION
Do not create/add test targets when this is not the root CMakeLists.txt - motivation is to ignore test targets when the library is fetched using CMake ubiquitous FetchContent.
