### PR TITLE
Disable tests by default for external-project/fetchcontent consumers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,16 @@ target_include_directories(${PROJECT_NAME} INTERFACE
   )
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
 
-enable_testing()
+option(PPRINTPP_BUILD_TESTING "Enable building tests." OFF)
 
-add_executable(${PROJECT_NAME}-test test/main.cpp)
-add_test(NAME ${PROJECT_NAME}-test COMMAND ${PROJECT_NAME}-test)
-target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-target_compile_options(${PROJECT_NAME}-test PRIVATE -Wall -Wextra -Werror)
+if(PPRINTPP_BUILD_TESTING)
+  enable_testing()
+
+  add_executable(${PROJECT_NAME}-test test/main.cpp)
+  add_test(NAME ${PROJECT_NAME}-test COMMAND ${PROJECT_NAME}-test)
+  target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+  target_compile_options(${PROJECT_NAME}-test PRIVATE -Wall -Wextra -Werror)
+endif()
 
 set(CPACK_PACKAGE_NAME "pprintpp")
 set(CPACK_PACKAGE_VENDOR "galowicz.de")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
 
 option(PPRINTPP_BUILD_TESTING "Enable building tests." OFF)
 
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(PPRINTPP_BUILD_TESTING ON)
+endif()
+
 if(PPRINTPP_BUILD_TESTING)
   enable_testing()
 


### PR DESCRIPTION
This PR does:

- disable tests by default
- enable them again if this project is not a sub-project

Fixes #24.

This way users of `fetchContent` or similar mechanisms do not get the pprintpp unit tests mix up with their projects.
But they still can activate them if wanted:

```CMake
cmake_minimum_required(VERSION 3.21)
project(fetchContent_example CXX)
include(FetchContent)

FetchContent_Declare(
  pprintpp
  GIT_REPOSITORY "https://github.com/tfc/pprintpp"
  GIT_TAG "004b60fd97c41b573dac5ea8f398a3c6ebd466ef"
  )

# enable unit tests for pprintpp if wanted
set(PPRINTPP_BUILD_TESTING ON CACHE INTERNAL "enable pprintpp tests")
FetchContent_MakeAvailable(pprintpp)

add_executable(${PROJECT_NAME} main.cpp)
target_link_libraries(${PROJECT_NAME} pprintpp::pprintpp)
```